### PR TITLE
Add $feed and $api to gf_salesforce_create_data filter

### DIFF
--- a/trunk/salesforce-api.php
+++ b/trunk/salesforce-api.php
@@ -1737,7 +1737,7 @@ jQuery(document).ready(function() {
 
 		}
 
-		$merge_vars = apply_filters( 'gf_salesforce_create_data', $merge_vars, $form, $entry );
+		$merge_vars = apply_filters( 'gf_salesforce_create_data', $merge_vars, $form, $entry, $feed, $api );
 
 		// Make sure the charset is UTF-8 for Salesforce.
 		$merge_vars = array_map(array('GFSalesforce', '_convert_to_utf_8'), $merge_vars);


### PR DESCRIPTION
Adds the $feed and $api variables into the gf_salesforce_create_data filter, so that additional things can be done in $merge_vars based on the feed options, and $api can be further tweaked (setAssignmentRuleHeader) based on the feed object name.
