### PR TITLE
3.0.1-beta

### DIFF
--- a/trunk/inc/daddy_analytics.addon.php
+++ b/trunk/inc/daddy_analytics.addon.php
@@ -163,47 +163,60 @@ if (class_exists("GFForms")) {
 		 */
 		public function plugin_settings_fields() {
 
-			return array(
-				array(
-					"title"  => sprintf(__("%s Configuration", 'gravity-forms-salesforce'), $this->get_service_name()),
-					"description" => $this->get_ad_text(),
-					"class" => 'clear',
-					"fields" => array(
-						array(
-							"name"    => "daddy_analytics_site_id",
-							"label"   => __("Site ID", "gravity-forms-salesforce"),
-							"type"    => "text",
-							"class"   => "medium code",
+			$fields = array();
+
+			$fields[] = array(
+				"title"  => sprintf(__("%s Configuration", 'gravity-forms-salesforce'), $this->get_service_name()),
+				"description" => $this->get_ad_text(),
+				"class" => 'clear',
+				"fields" => array(
+					array(
+						"name"    => "daddy_analytics_token",
+						"label"   => __("Token", "gravity-forms-salesforce"),
+						"type"    => "text",
+						"class"   => "medium code",
+					),
+					array(
+						"name"    => "daddy_analytics_webtolead_url_id",
+						"label"   => __("Web to Lead URL ID", "gravity-forms-salesforce"),
+						"type"    => "text",
+						"class"   => "medium code",
+					),
+					array(
+						"name"    => "daddy_analytics_site_id",
+						"label"   => __("Site ID", "gravity-forms-salesforce"),
+						"type"    => "text",
+						"class"   => "medium code",
+					),
+					array(
+						"name"    => "add_js",
+						"label"   => sprintf(__("Add Javascript? %sDisable you want to add tracking code yourself.%s", "gravity-forms-salesforce"), '<span class="howto">', '</span>'),
+						"type"    => "checkbox",
+						"dependency" => array(&$this, 'using_da'),
+						"choices" => array(
+							array(
+								"name" => 'yes',
+								"label" => 'Add tracking script to the site footer?',
+								"value" => 1,
+								'default_value' => 1,
+							)
 						),
-						array(
-							"name"    => "daddy_analytics_token",
-							"label"   => __("Token", "gravity-forms-salesforce"),
-							"type"    => "text",
-							"class"   => "medium code",
-						),
-						array(
-							"name"    => "daddy_analytics_webtolead_url_id",
-							"label"   => __("Web to Lead URL ID", "gravity-forms-salesforce"),
-							"type"    => "text",
-							"class"   => "medium code",
-						),
-						array(
-							"name"    => "add_js",
-							"label"   => sprintf(__("Add Javascript? %sDisable you want to add tracking code yourself.%s", "gravity-forms-salesforce"), '<span class="howto">', '</span>'),
-							"type"    => "checkbox",
-							"dependency" => array(&$this, 'using_da'),
-							"choices" => array(
-								array(
-									"name" => 'yes',
-									"label" => 'Add tracking script to the site footer?',
-									"value" => 1,
-									'default_value' => 1,
-								)
-							),
+					),
+					array(
+						'name' => 'Save',
+						'type' => 'save',
+						'messages' => array(
+							'success' => __('Settings updated successfully.', 'gravity-forms-salesforce'),
+							'error' => __('Settings failed to update successfully.', 'gravity-forms-salesforce')
 						)
 					)
-				),
-				array(
+				)
+			);
+
+			// If you need to define custom API names, you can do so here.
+			// Sometimes Salesforce adds prefixes.
+			if( apply_filters( 'gf_salesforce_custom_da_api_names', false ) ) {
+				$fields[] = array(
 					"title"  => __("Salesforce API Name Configuration", 'gravity-forms-salesforce'),
 					"description" => wpautop(sprintf(__('Make sure the API names below match what is in Salesforce on your %sLead Fields%s page.', 'gravity-forms-salesforce'), '<a href="https://na11.salesforce.com/p/setup/layout/LayoutFieldList?setupid=LeadFields&amp;type=Lead">', '</a>')).wpautop(sprintf('<img src="%s" width="658" height="133" style="max-width:100%%;" alt="Salesforce API Fields" />', plugins_url( 'assets/images/daddy_analytics/Salesforce_API_Fields.png', KWS_GF_Salesforce::$file ))),
 					"style" => 'padding-top: 0;',
@@ -231,8 +244,10 @@ if (class_exists("GFForms")) {
 							)
 						)
 					)
-				)
-			);
+				);
+			}
+
+			return $fields;
 		}
 
 		function get_ad_term(){

--- a/trunk/inc/salesforce-api.php
+++ b/trunk/inc/salesforce-api.php
@@ -897,7 +897,8 @@ class GFSalesforce {
 
 		// If the settings aren't set...return false
 		if(!is_array($settings) || empty($settings)) {
-			#return false;
+			self::log_error("get_api(): Settings not set, so we can't get the Salesforce connection.");
+			return false;
 		}
 
 		extract($settings);

--- a/trunk/readme.txt
+++ b/trunk/readme.txt
@@ -257,7 +257,11 @@ This plugin is released under a GPL license.
 
 == Changelog ==
 
-= 3.0 (May 9, 2014) =
+= 3.0.1 (May 11, 2014) =
+* Modified: Hide Daddy Analytics custom API Name settings, unless the `gf_salesforce_custom_da_api_names` filter returns true.
+* Fixed (API): Return false in `get_api()` method when settings are empty.
+
+= 3.0.0 (May 9, 2014) =
 * __!!MAJOR UPDATE!!__ Please read through the changes below.
 * __API Add-on Changes__
     - __You will need to update your settings__ after installing the plugin.

--- a/trunk/salesforce.php
+++ b/trunk/salesforce.php
@@ -33,7 +33,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 class KWS_GF_Salesforce {
 
-    const version = '3.0.0-beta';
+    const version = '3.0.1-beta';
     static $file;
     static $plugin_dir_path;
 


### PR DESCRIPTION
= 3.0.1 (May 11, 2014) =
- Modified: Hide Daddy Analytics custom API Name settings, unless the
  `gf_salesforce_custom_da_api_names` filter returns true.
- Fixed (API): Return false in `get_api()` method when settings are
  empty.
