### PR TITLE
Curl ip6 check

### DIFF
--- a/trunk/inc/salesforce-api.php
+++ b/trunk/inc/salesforce-api.php
@@ -318,10 +318,10 @@ class GFSalesforce {
 		);
 
 		$client = new CurlClient;
-    // Salesforce doesn't support IP6, so if libcurl supports IP6 and IP4, force IP4
-    if (defined(CURLOPT_IPRESOLVE) && defined(CURL_IPRESOLVE_V4)) {
-      $client->setCurlParameters( array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 ));
-    }
+		// Salesforce doesn't support IP6, so if libcurl supports IP6 and IP4, force IP4
+		if (defined('CURLOPT_IPRESOLVE') && defined('CURL_IPRESOLVE_V4')) {
+			$client->setCurlParameters( array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 ));
+		}
 		
 		$storage = new WordPressMemory;
 

--- a/trunk/inc/salesforce-api.php
+++ b/trunk/inc/salesforce-api.php
@@ -318,8 +318,10 @@ class GFSalesforce {
 		);
 
 		$client = new CurlClient;
-		// Salesforce doesn't support IP6, so force IP4
-		$client->setCurlParameters( array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 ));
+    // Salesforce doesn't support IP6, so if libcurl supports IP6 and IP4, force IP4
+    if (defined(CURLOPT_IPRESOLVE) && defined(CURL_IPRESOLVE_V4)) {
+      $client->setCurlParameters( array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 ));
+    }
 		
 		$storage = new WordPressMemory;
 


### PR DESCRIPTION
It occurred to me that older versions of libcurl may not support IP6, so the constants we have to pass to it to force IP4 may not exist.

Out of an abundance of caution, we should check for them first before applying our options.