### PR TITLE
Fix multifeed issues where Ids are transferred between feeds improperly

### DIFF
--- a/trunk/inc/salesforce-api.php
+++ b/trunk/inc/salesforce-api.php
@@ -2321,7 +2321,7 @@ class GFSalesforce {
 				self::log_debug(sprintf('%s: Upserting using primary field of `%s`',
 											__METHOD__, $feed['meta']['primary_field']));
 
-				if(empty(self::$instance->result->id)) {
+				if(empty(self::$instance->result->id) || (isset($Account->fields['Id']) && $Account->fields['Id'] != "")) {
 
 					// old upsert
 					// https://www.salesforce.com/us/developer/docs/api/Content/sforce_api_calls_upsert.htm


### PR DESCRIPTION
We came across this issue where we have two feeds on a single form. The form passes the Ids for both SF Objects we are trying to update. Back in 3.0.6, this worked fine, where the form would fire off both feeds and push data into the respective objects. I believe now the code carries over the Id of a successful upsert from one feed to the second (on one form), improperly assuming there is no Id for the second feed already set. I just added some code to ensure the case where an Id is already set on the second feed, the correct Id is sent. Otherwise, updates to a second object are not possible since the Id of the first upsert would not correspond to the second object.
