### PR TITLE
Salesforce API network issue notification

### DIFF
--- a/trunk/inc/salesforce-api.php
+++ b/trunk/inc/salesforce-api.php
@@ -318,8 +318,10 @@ class GFSalesforce {
 		);
 
 		$client = new CurlClient;
-		// Salesforce doesn't support IP6, so force IP4
-		$client->setCurlParameters( array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 ));
+    // Salesforce doesn't support IP6, so if libcurl supports IP6 and IP4, force IP4
+    if (defined(CURLOPT_IPRESOLVE) && defined(CURL_IPRESOLVE_V4)) {
+      $client->setCurlParameters( array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 ));
+    }
 		
 		$storage = new WordPressMemory;
 


### PR DESCRIPTION
Add notification of network level failures (causing form data not to be sent via Salesforce API) so that admins are notified, and can take remedial action

Closes #281 
