### PR TITLE
SF endpoint 2017 update: changed www subdomain to webto

### DIFF
--- a/trunk/inc/web-to-lead.php
+++ b/trunk/inc/web-to-lead.php
@@ -708,9 +708,9 @@ if (class_exists("GFForms")) {
 			$args = apply_filters( 'gf_salesforce_request_args', $args, $test );
 
 			// Use test/www subdomain based on whether this is a test or live
-			$sub = apply_filters( 'gf_salesforce_request_subdomain', ($test ? 'test' : 'www'), $test );
+			$sub = apply_filters( 'gf_salesforce_request_subdomain', ($test ? 'test' : 'webto'), $test );
 
-			// Use (test|www) subdomain and WebTo(Lead|Case) based on setting
+			// Use (test|webto) subdomain and WebTo(Lead|Case) based on setting
 			$url = apply_filters( 'gf_salesforce_request_url', sprintf('https://%s.salesforce.com/servlet/servlet.WebTo%s?encoding=UTF-8', $sub, $type), $args);
 
 			self::log_debug( sprintf("This is the data sent to %s (at %s:\n%s)", $this->_service_name, $url, print_r($args, true)) );


### PR DESCRIPTION
Description of change from Salesforce:
https://help.salesforce.com/articleView?eid=ss-tc&id=Updating-the-Web-to
-Case-and-Web-to-Lead-Endpoint-URL&language=en_US&type=1